### PR TITLE
Fix: firefox vertical align center

### DIFF
--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -155,7 +155,7 @@ if (count($emr_app)) {
         }
     </script>
 </head>
-<body class="login">
+<body class="login h-100">
   <form method="POST" id="login_form" autocomplete="off" action="../main/main_screen.php?auth=login&site=<?php echo attr($_SESSION['site_id']); ?>" target="_top" name="login_form">
       <div class="row login-row align-items-center m-5">
           <div class="col-md-6 p-5 login-area order-2 order-md-1">


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
In the Firefox browser, The login form didn't vertical-align center.

Before:
![image](https://user-images.githubusercontent.com/22230889/85630555-6dbab380-b6a6-11ea-83eb-14ff3535b904.png)

After:
![image](https://user-images.githubusercontent.com/22230889/85630580-7b703900-b6a6-11ea-9142-968ffc96158d.png)
